### PR TITLE
add classification

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,14 +2,9 @@
 FROM python:3.8-slim
 
 # 必要なパッケージのインストール
-RUN apt-get update 
-RUN pip install jupyterlab
-RUN pip install scikit-learn
-RUN pip install pandas
-RUN pip install numpy
-RUN pip install feedparser
-RUN pip install flake8
-RUN pip install black
-RUN pip install isort
+RUN apt-get update && apt-get install -y gcc python3-dev
+COPY requirements.txt /work/requirements.txt
+RUN pip install -r /work/requirements.txt
+RUN pip install --upgrade jupyter ipywidgets
 # Jupyter Labの起動コマンド設定
-CMD ["jupyter", "lab", "--ip=0.0.0.0", "--allow-root", "--NotebookApp.token=''", "--NotebookApp.password=''"]
+CMD ["jupyter", "lab", "--ip=0.0.0.0", "--allow-root", "--NotebookApp.token=''", "--NotebookApp.password=''","--port=8000"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -6,5 +6,5 @@ services:
     volumes:
       - ../work:/work
     ports:
-      - "8888:8888"
+      - "8000:8000"
     container_name: jupyter_lab_container

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -1,0 +1,10 @@
+jupyterlab
+pandas
+numpy
+feedparser
+flake8
+black
+isort
+openai==1.12.0
+bertopic
+python-dotenv

--- a/work/notebook/.env.sample
+++ b/work/notebook/.env.sample
@@ -1,0 +1,1 @@
+OPENAI_API_KEY =

--- a/work/notebook/retrieve_and_classification.ipynb
+++ b/work/notebook/retrieve_and_classification.ipynb
@@ -1,0 +1,170 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "0e8fd72c-0e9e-4b70-9e49-39c356c8d586",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ[\"TOKENIZERS_PARALLELISM\"] = \"false\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "d0fecb90-9bee-4a67-afcd-a7701e73187e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# スクリプトからライブラリのインポート\n",
+    "import sys\n",
+    "sys.path.append('../scripts')\n",
+    "\n",
+    "from retrieve_paper_from_arxiv import Retrieve_Arxiv\n",
+    "from classification_paper import Classification_Topic\n",
+    "import pandas as pd\n",
+    "from dotenv import load_dotenv\n",
+    "\n",
+    "load_dotenv()\n",
+    "openai_api_key = os.getenv('OPENAI_API_KEY')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "93be1f71-ae9b-4c01-995e-b718cac067a4",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "検索したい単語を入力してください: ViT\n",
+      "検索する論文の数を入力してください: 1000\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ユーザー依存の変数の宣言\n",
+    "keyword = str(input(\"検索したい単語を入力してください:\"))\n",
+    "max_num = int(input(\"検索する論文の数を入力してください:\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "b7321405-21e2-4d16-9954-9c4bfabbc549",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "「ViT」について検索をかけ、その内容を1000件まとめます\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(\"「{keyword}」について検索をかけ、その内容を{max_num}件まとめます\".format(keyword=keyword,max_num=max_num))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "101950ea-3398-425b-a6bf-4492ef685c74",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdin",
+     "output_type": "stream",
+     "text": [
+      "論文に適用するクラスタの数を入力してください: 30\n"
+     ]
+    }
+   ],
+   "source": [
+    "# ここで指定した数がトピックの分類数になるとは限りません\n",
+    "num_topics = int(input(\"論文に適用するクラスタの数を入力してください:\"))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "db3b1f5c-841b-4513-87ae-80d369b2ca87",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# インスタンスの定義\n",
+    "file_name = \"sample.csv\"\n",
+    "re = Retrieve_Arxiv(saved_file_name=file_name)\n",
+    "cl = Classification_Topic(saved_file_name=file_name,\n",
+    "                          openai_api_key=openai_api_key)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "5125e6b7-62e9-4f4a-b7a0-65227dc066b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# キーワードに一致する論文をmax_num分だけ取得する\n",
+    "# retrieved_paper.csvが作成されればOK\n",
+    "re.retrieve(keyword=keyword,max_num=max_num)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "6774e122-8d84-47e4-8985-a0402c25a14e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 論文をトピック分類する\n",
+    "cl.classification_papers_csv(num_topics=num_topics)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "76501885-7280-4eee-a6bb-e89741ac4e41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# キーワード/トピック/papers_data.csvでCSVをトピック別に保存する\n",
+    "cl.make_and_save_topic_csv(keyword)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "abac0eb9-3ad0-4ab4-a0d4-396ee54fa594",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.18"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/work/scripts/classification_paper.py
+++ b/work/scripts/classification_paper.py
@@ -1,0 +1,83 @@
+import os
+import re
+import sys
+
+import openai
+import pandas as pd
+from bertopic import BERTopic
+from bertopic.backend import OpenAIBackend
+from bertopic.representation import OpenAI
+from sklearn.cluster import KMeans
+
+sys.path.append("../utils")
+from openai_embeddings import OpenAICustomBackend
+
+
+class Classification_Topic:
+    def __init__(
+        self, openai_api_key: str, saved_file_name: str = "retrieved_paper.csv"
+    ):
+
+        self.api_key = openai_api_key
+        self.saved_file_name = saved_file_name
+        self.docs_df = pd.DataFrame()
+        self.topics = []
+        self.probs = []
+        self.df_info = pd.DataFrame()
+
+    def classification_papers_csv(self, num_topics: int):
+        # 　ドキュメントのデータフレームからアブストラクトのみを抽出
+        self.docs_df = pd.read_csv("/work/data/" + self.saved_file_name)
+        doc_list = list(self.docs_df["Abstruct"])
+        # 　OpenAI系統のモデルの宣言
+        client = openai.OpenAI(api_key=self.api_key)
+        embedding_model = OpenAICustomBackend(client=client)
+        prompt = """
+            I have a topic that contains the following documents:
+            [DOCUMENTS]
+            The topic is described by the following keywords: [KEYWORDS]
+            Based on the information above, extract a short but highly descriptive topic label of at most 5 words.
+            The number of words should not exceed 100 characters for the entire label
+            Make sure it is in the following format:
+            topic: <topic label>
+            """
+        representation_model = OpenAI(
+            client, model="gpt-3.5-turbo", chat=True, prompt=prompt
+        )
+        # 分類モデルの定義
+        cluster_model = KMeans(n_clusters=num_topics)
+        topic_model = BERTopic(
+            language="english",
+            calculate_probabilities=True,
+            nr_topics="auto",
+            embedding_model=embedding_model,
+            representation_model=representation_model,
+            hdbscan_model=cluster_model,
+        )
+        # 分類モデルでのトピック分類
+        self.topics, self.probs = topic_model.fit_transform(doc_list)
+        self.df_info = topic_model.get_topic_info()
+
+    def make_and_save_topic_csv(self, keyword):
+        # トピック分類後はトピックのインデックスが振られているためトピック名に変更する
+        self.docs_df["Topic"] = [
+            self.df_info[self.df_info["Topic"] == num]["Name"].values[0]
+            for num in self.topics
+        ]
+        # 保存するディレクトリの作成
+        dir = "/work/data/{}".format(keyword)
+        if not os.path.exists(dir):
+            os.makedirs(dir)
+        for topic in self.df_info["Name"].unique():
+            topic = re.sub(r"^\d+_", "", topic)
+            topic_dir = os.path.join(dir, topic)
+            if not os.path.exists(topic_dir):
+                os.makedirs(topic_dir)
+        # データフレームをトピックごとに分割
+        docs_df_grouped = self.docs_df.groupby("Topic")
+        dfs = {re.sub(r"^\d+_", "", topic): group for topic, group in docs_df_grouped}
+        for topic in self.df_info["Name"].unique():
+            topic = re.sub(r"^\d+_", "", topic)
+            topic_file_path = os.path.join(dir, topic, "papers_data.csv")
+            # 保存
+            dfs[topic].to_csv(topic_file_path)

--- a/work/scripts/retrieve_paper_from_arxiv.py
+++ b/work/scripts/retrieve_paper_from_arxiv.py
@@ -5,14 +5,14 @@ import pandas as pd
 
 
 class Retrieve_Arxiv:
-    def __init__(self, Saved_file_path: str) -> None:
+    def __init__(self, saved_file_name: str="retrieved_paper.csv") -> None:
         """コンストラクタ
 
         Args:
-            Saved_file_path (str): 保存するCSVファイルの名前
+            saved_file_name (str): 保存するCSVファイルの名前
         """
-        assert Saved_file_path.endswith(".csv"), "ファイル名が.csvで終わっていません。"
-        self.Saved_file_path = Saved_file_path
+        assert saved_file_name.endswith(".csv"), "ファイル名が.csvで終わっていません。"
+        self.saved_file_name = saved_file_name
 
     def retrieve(self, keyword: str, max_num: int) -> None:
         """論文をarxivから検索、CSVにして保存まで一括で行う関数
@@ -63,11 +63,11 @@ class Retrieve_Arxiv:
         Args:
             df (pd.DataFrame): 取得した論文について必要な情報を抜き出したデータフレーム
         """
-        filename = "/work/data/" + self.Saved_file_path
+        filename = "/work/data/" + self.saved_file_name
         df.to_csv(filename, encoding="utf-8")
 
     def __get_requests_message(self, keyword: str, max_num: int) -> str:
-        """リクエストメッセージをコマンドライン引数から作成する関数
+        """リクエストメッセージをコマンドライン引数から作成する内部関数
 
         Args:
             keyword (str): 検索したい論文に関連する単語
@@ -83,7 +83,7 @@ class Retrieve_Arxiv:
 
 
 def main(keyword, max_num):
-    re = Retrieve_Arxiv("retrieved_paper.csv")
+    re = Retrieve_Arxiv()
     re.retrieve(keyword, max_num)
 
 

--- a/work/utils/openai_embeddings.py
+++ b/work/utils/openai_embeddings.py
@@ -1,0 +1,85 @@
+import time
+import openai
+import numpy as np
+from tqdm import tqdm
+from typing import List, Mapping, Any
+from bertopic.backend import BaseEmbedder
+
+
+class OpenAICustomBackend(BaseEmbedder):
+    """ OpenAI Embedding Model
+
+    Arguments:
+        client: A `openai.OpenAI` client.
+        embedding_model: An OpenAI model. Default is
+                         For an overview of models see:
+                         https://platform.openai.com/docs/models/embeddings
+        delay_in_seconds: If a `batch_size` is given, use this set
+                          the delay in seconds between batches.
+        batch_size: The size of each batch.
+        generator_kwargs: Kwargs passed to `openai.Embedding.create`.
+                          Can be used to define custom engines or
+                          deployment_ids.
+
+    Examples:
+
+    ```python
+    import openai
+    from bertopic.backend import OpenAIBackend
+
+    client = openai.OpenAI(api_key="sk-...")
+    openai_embedder = OpenAIBackend(client, "text-embedding-ada-002")
+    ```
+    """
+    def __init__(self,
+                 client,
+                 embedding_model: str = "text-embedding-ada-002",
+                 delay_in_seconds: float = None,
+                 batch_size: int = None,
+                 generator_kwargs: Mapping[str, Any] = {}):
+        super().__init__()
+        self.embedding_model = embedding_model
+        self.delay_in_seconds = delay_in_seconds
+        self.batch_size = batch_size
+        self.generator_kwargs = generator_kwargs
+        self.client = client
+
+        if self.generator_kwargs.get("model"):
+            self.embedding_model = generator_kwargs.get("model")
+        elif not self.generator_kwargs.get("engine"):
+            self.generator_kwargs["model"] = self.embedding_model
+
+    def embed(self,
+              documents: List[str],
+              verbose: bool = False) -> np.ndarray:
+        """ Embed a list of n documents/words into an n-dimensional
+        matrix of embeddings
+
+        Arguments:
+            documents: A list of documents or words to be embedded
+            verbose: Controls the verbosity of the process
+
+        Returns:
+            Document/words embeddings with shape (n, m) with `n` documents/words
+            that each have an embeddings size of `m`
+        """
+        # Batch-wise embedding extraction
+        if self.batch_size is not None:
+            embeddings = []
+            for batch in tqdm(self._chunks(documents), disable=not verbose):
+                response = self.client.embeddings.create(input=batch, **self.generator_kwargs)
+                embeddings.extend([r.embedding for r in response.data])
+
+                # Delay subsequent calls
+                if self.delay_in_seconds:
+                    time.sleep(self.delay_in_seconds)
+
+        # Extract embeddings all at once
+        else:
+            response = self.client.embeddings.create(input=documents, **self.generator_kwargs)
+            embeddings = [r.embedding for r in response.data]
+        return np.array(embeddings)
+
+    def _chunks(self, documents):
+        for i in range(0, len(documents), self.batch_size):
+            yield documents[i:i + self.batch_size]


### PR DESCRIPTION
## 論文の検索を行い任意のファイルパスに保存するスクリプトの実装
---

### 何ができるようになったか
- classification_paper.pyの実行によってスクレイピングした論文をクラス分類することができるようになった
- それぞれの機能を一括で実行することのできるノートブックを作成した

### 実行手順(まとめて)
- [ ] docker compose up -dによってコンテナを立ち上げる。localhost:8000にアクセスする
- [ ] retrieve_and_classification.ipynbを全て実行する。キーワード、検索数、クラスタ数に分けて指定する
- [ ] re.retrieve()で検索、CSV作成
- [ ] cl.classification_papers_csv()でトピック分類(この時点ではディレクトリは作成されない)
- [ ] cl.make_and_save_topic_csv()でディレクトリ作成、CSVの保存
- [ ] data以下にキーワード名/トピック名のディレクトリが作成され、内部に論文をまとめたCSVが作成される

### その他やっておいたこと
1. Dockerfileの調整
2. .envによるAPIキーの管理
3. OpenaiCustomBackendによるエンべディングモデルの呼び出し