### PR TITLE
Feature branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
 キーワード:ViT、<br>
 検索数1000件にしてみる<br>
 <img width="487" alt="スクリーンショット 2024-02-13 23 12 52" src="https://github.com/shun31y/Paper_Classification/assets/145087663/dd661d95-d0fa-4e66-98cb-b45d6b2c0bad"><br>
-クラスタ数は30で指定する。<br>
+最大クラスタ数は30で指定する。<br>
 <img width="219" alt="スクリーンショット 2024-02-13 23 13 30" src="https://github.com/shun31y/Paper_Classification/assets/145087663/8e577b86-ad53-459d-ad34-1850de294f9f"><br>
 全てのセルを実行後キーワード名のディレクトリが作成される<br>
 <img width="499" alt="スクリーンショット 2024-02-13 23 13 48" src="https://github.com/shun31y/Paper_Classification/assets/145087663/93102bc3-f7ff-4f86-b664-6d31710096c3"><br>

--- a/docker/requirements.txt
+++ b/docker/requirements.txt
@@ -8,3 +8,7 @@ isort
 openai==1.12.0
 bertopic
 python-dotenv
+pyclustering
+PIL
+scipy
+matplotlib

--- a/work/notebook/retrieve_and_classification.ipynb
+++ b/work/notebook/retrieve_and_classification.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 168,
    "id": "0e8fd72c-0e9e-4b70-9e49-39c356c8d586",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 169,
    "id": "d0fecb90-9bee-4a67-afcd-a7701e73187e",
    "metadata": {},
    "outputs": [],
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 170,
    "id": "93be1f71-ae9b-4c01-995e-b718cac067a4",
    "metadata": {},
    "outputs": [
@@ -41,8 +41,8 @@
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      "検索したい単語を入力してください: network\n",
-      "検索する論文の数を入力してください: 2000\n"
+      "検索したい単語を入力してください: hollow\n",
+      "検索する論文の数を入力してください: 120\n"
      ]
     }
    ],
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 171,
    "id": "b7321405-21e2-4d16-9954-9c4bfabbc549",
    "metadata": {},
    "outputs": [
@@ -62,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "「network」について検索をかけ、その内容を2000件まとめます\n"
+      "「hollow」について検索をかけ、その内容を120件まとめます\n"
      ]
     }
    ],
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 40,
+   "execution_count": 172,
    "id": "101950ea-3398-425b-a6bf-4492ef685c74",
    "metadata": {},
    "outputs": [
@@ -80,32 +80,32 @@
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      "論文に適用するクラスタの最大数を入力してください (Prefered more than 30): 50\n"
+      "論文に適用するクラスタの最大数を入力してください (Preferred more than 30): 10\n"
      ]
     }
    ],
    "source": [
     "# ここで指定した数がトピックの分類数になるとは限りません\n",
-    "num_topics = int(input(\"論文に適用するクラスタの最大数を入力してください (Prefered more than 30):\"))"
+    "num_topics = int(input(\"論文に適用するクラスタの最大数を入力してください (Preferred more than 30):\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 173,
    "id": "db3b1f5c-841b-4513-87ae-80d369b2ca87",
    "metadata": {},
    "outputs": [],
    "source": [
     "# インスタンスの定義\n",
     "file_name = \"sample.csv\"\n",
-    "re = Retrieve_Arxiv(saved_file_name=file_name)\n",
+    "re = Retrieve_Arxiv()\n",
     "cl = Classification_Topic(saved_file_name=file_name,\n",
     "                          openai_api_key=openai_api_key)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 174,
    "id": "5125e6b7-62e9-4f4a-b7a0-65227dc066b3",
    "metadata": {},
    "outputs": [],
@@ -117,9 +117,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 43,
+   "execution_count": 175,
    "id": "6774e122-8d84-47e4-8985-a0402c25a14e",
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# 論文をトピック分類する\n",
@@ -128,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 176,
    "id": "76501885-7280-4eee-a6bb-e89741ac4e41",
    "metadata": {},
    "outputs": [],

--- a/work/notebook/retrieve_and_classification.ipynb
+++ b/work/notebook/retrieve_and_classification.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 36,
    "id": "0e8fd72c-0e9e-4b70-9e49-39c356c8d586",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 37,
    "id": "d0fecb90-9bee-4a67-afcd-a7701e73187e",
    "metadata": {},
    "outputs": [],
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 38,
    "id": "93be1f71-ae9b-4c01-995e-b718cac067a4",
    "metadata": {},
    "outputs": [
@@ -41,8 +41,8 @@
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      "検索したい単語を入力してください: ViT\n",
-      "検索する論文の数を入力してください: 1000\n"
+      "検索したい単語を入力してください: network\n",
+      "検索する論文の数を入力してください: 2000\n"
      ]
     }
    ],
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 39,
    "id": "b7321405-21e2-4d16-9954-9c4bfabbc549",
    "metadata": {},
    "outputs": [
@@ -62,7 +62,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "「ViT」について検索をかけ、その内容を1000件まとめます\n"
+      "「network」について検索をかけ、その内容を2000件まとめます\n"
      ]
     }
    ],
@@ -72,7 +72,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 40,
    "id": "101950ea-3398-425b-a6bf-4492ef685c74",
    "metadata": {},
    "outputs": [
@@ -80,18 +80,18 @@
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      "論文に適用するクラスタの数を入力してください: 30\n"
+      "論文に適用するクラスタの最大数を入力してください (Prefered more than 30): 50\n"
      ]
     }
    ],
    "source": [
     "# ここで指定した数がトピックの分類数になるとは限りません\n",
-    "num_topics = int(input(\"論文に適用するクラスタの数を入力してください:\"))"
+    "num_topics = int(input(\"論文に適用するクラスタの最大数を入力してください (Prefered more than 30):\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 41,
    "id": "db3b1f5c-841b-4513-87ae-80d369b2ca87",
    "metadata": {},
    "outputs": [],
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 42,
    "id": "5125e6b7-62e9-4f4a-b7a0-65227dc066b3",
    "metadata": {},
    "outputs": [],
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 43,
    "id": "6774e122-8d84-47e4-8985-a0402c25a14e",
    "metadata": {},
    "outputs": [],
@@ -128,7 +128,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 44,
    "id": "76501885-7280-4eee-a6bb-e89741ac4e41",
    "metadata": {},
    "outputs": [],

--- a/work/notebook/retrieve_and_classification.ipynb
+++ b/work/notebook/retrieve_and_classification.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 168,
+   "execution_count": 201,
    "id": "0e8fd72c-0e9e-4b70-9e49-39c356c8d586",
    "metadata": {},
    "outputs": [],
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 169,
+   "execution_count": 202,
    "id": "d0fecb90-9bee-4a67-afcd-a7701e73187e",
    "metadata": {},
    "outputs": [],
@@ -33,7 +33,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 170,
+   "execution_count": 210,
    "id": "93be1f71-ae9b-4c01-995e-b718cac067a4",
    "metadata": {},
    "outputs": [
@@ -41,20 +41,20 @@
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      "検索したい単語を入力してください: hollow\n",
-      "検索する論文の数を入力してください: 120\n"
+      "検索したい単語を入力してください: machine learning\n",
+      "検索する論文の数を入力してください: 1000\n"
      ]
     }
    ],
    "source": [
     "# ユーザー依存の変数の宣言\n",
-    "keyword = str(input(\"検索したい単語を入力してください:\"))\n",
+    "keyword = str(input(\"検索したい単語を入力してください:\")).replace(\" \", \"%20\")\n",
     "max_num = int(input(\"検索する論文の数を入力してください:\"))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 171,
+   "execution_count": 211,
    "id": "b7321405-21e2-4d16-9954-9c4bfabbc549",
    "metadata": {},
    "outputs": [
@@ -62,17 +62,17 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "「hollow」について検索をかけ、その内容を120件まとめます\n"
+      "「machine learning」について検索をかけ、その内容を1000件まとめます\n"
      ]
     }
    ],
    "source": [
-    "print(\"「{keyword}」について検索をかけ、その内容を{max_num}件まとめます\".format(keyword=keyword,max_num=max_num))"
+    "print(\"「{keyword}」について検索をかけ、その内容を{max_num}件まとめます\".format(keyword=keyword.replace(\"%20\", \" \"),max_num=max_num))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 172,
+   "execution_count": 205,
    "id": "101950ea-3398-425b-a6bf-4492ef685c74",
    "metadata": {},
    "outputs": [
@@ -80,7 +80,7 @@
      "name": "stdin",
      "output_type": "stream",
      "text": [
-      "論文に適用するクラスタの最大数を入力してください (Preferred more than 30): 10\n"
+      "論文に適用するクラスタの最大数を入力してください (Preferred more than 30): 50\n"
      ]
     }
    ],
@@ -91,7 +91,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 173,
+   "execution_count": 206,
    "id": "db3b1f5c-841b-4513-87ae-80d369b2ca87",
    "metadata": {},
    "outputs": [],
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 174,
+   "execution_count": 207,
    "id": "5125e6b7-62e9-4f4a-b7a0-65227dc066b3",
    "metadata": {},
    "outputs": [],
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 175,
+   "execution_count": 208,
    "id": "6774e122-8d84-47e4-8985-a0402c25a14e",
    "metadata": {
     "scrolled": true
@@ -130,7 +130,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 176,
+   "execution_count": 209,
    "id": "76501885-7280-4eee-a6bb-e89741ac4e41",
    "metadata": {},
    "outputs": [],

--- a/work/notebook/retrieve_and_classification.ipynb
+++ b/work/notebook/retrieve_and_classification.ipynb
@@ -117,26 +117,74 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 208,
+   "execution_count": 213,
    "id": "6774e122-8d84-47e4-8985-a0402c25a14e",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "33個のトピックに分類されました。\n"
+     ]
+    }
+   ],
    "source": [
     "# 論文をトピック分類する\n",
-    "cl.classification_papers_csv(num_topics=num_topics)"
+    "cl.classification_papers_csv(num_topics=num_topics)\n",
+    "print(\"{K}個のクラスタに分類されました。\".format(K=len(cl.df_info[\"Name\"].unique())))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 209,
+   "execution_count": 214,
    "id": "76501885-7280-4eee-a6bb-e89741ac4e41",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['0_Quantum Spin Exchange in Kagome' '1_Autonomous LLMs in Cybersecurity'\n",
+      " '2_Distribution-Free Dynamics Learning'\n",
+      " '3_High-velocity stellar motion modeling'\n",
+      " '4_Complex Fluid-Solid Interactions' '5_Exploring GenAI Impact on VR'\n",
+      " '6_Enhanced Conversational Search System'\n",
+      " '7_Particle Physics Data Analysis'\n",
+      " '8_Quantum Gravity Experiments Analysis'\n",
+      " '9_Nonlinear Wave Propagation in Complex Media'\n",
+      " '10_Exoplanet Formation and Magnetic Interactions'\n",
+      " '11_Protein Side-Chain Torsional Prediction'\n",
+      " '12_Quantum Proof Search & Parity-Encoding'\n",
+      " '13_Innovative Mathematical Reasoning Tools'\n",
+      " '14_Mobile Health App Explanation Analysis'\n",
+      " '15_Hair Modeling with Gaussian Representation'\n",
+      " '16_Intelligent Graph Analysis Environment'\n",
+      " '17_Multi-modal Anime Illustration Recommendation Fusion'\n",
+      " '18_Advancements in Nuclear Physics'\n",
+      " '19_Human-Robot Shared Autonomy Studies'\n",
+      " '20_Renormalization Scheme Restoring Chiral Symmetry'\n",
+      " '21_Peer Acknowledgement Impact on Learner Engagement'\n",
+      " '22_Resoformer for EV Vibration Forecasting'\n",
+      " '23_Dissipative NEGF Theory Extension'\n",
+      " '24_Enhancing Empathetic Multimodal Dialogue'\n",
+      " '25_Bosonic Impurities in Energy Study'\n",
+      " '26_Motion Guidance in XR Technology'\n",
+      " \"27_LLMs' Social Network Behavior Study\"\n",
+      " '28_Cell Signaling Pulsatile Dynamics'\n",
+      " '29_Molecular Solid Energy Approximations'\n",
+      " '30_AutoAct automatic agent learning framework'\n",
+      " '31_Efficient Wearable ECG Arrhythmia Analysis'\n",
+      " '32_Non-Periodic ALPs in Dark Matter']\n"
+     ]
+    }
+   ],
    "source": [
     "# キーワード/トピック/papers_data.csvでCSVをトピック別に保存する\n",
-    "cl.make_and_save_topic_csv(keyword)"
+    "cl.make_and_save_topic_csv(keyword)\n",
+    "print(cl.df_info[\"Name\"].unique())"
    ]
   },
   {

--- a/work/scripts/classification_paper.py
+++ b/work/scripts/classification_paper.py
@@ -66,6 +66,8 @@ class Classification_Topic:
         self.df_info = xmeans_instance.get_clusters()
 
     def make_and_save_topic_csv(self, keyword):
+        #URL用に変換したキーワードをもとに戻す
+        keyword = keyword.replace("%20", " ")
         # トピック分類後はトピックのインデックスが振られているためトピック名に変更する
         self.docs_df["Topic"] = [
             self.df_info[self.df_info["Topic"] == num]["Name"].values[0]

--- a/work/scripts/retrieve_paper_from_arxiv.py
+++ b/work/scripts/retrieve_paper_from_arxiv.py
@@ -5,17 +5,10 @@ import pandas as pd
 
 
 class Retrieve_Arxiv:
-    def __init__(self, saved_file_name: str="retrieved_paper.csv") -> None:
-        """コンストラクタ
-
-        Args:
-            saved_file_name (str): 保存するCSVファイルの名前
-        """
-        assert saved_file_name.endswith(".csv"), "ファイル名が.csvで終わっていません。"
-        self.saved_file_name = saved_file_name
+    def __init__(self):
 
     def retrieve(self, keyword: str, max_num: int) -> None:
-        """論文をarxivから検索、CSVにして保存まで一括で行う関数
+        """論文をarxivから検索、dfにするまで一括で行う関数
 
         Args:
             keyword (str): 検索したい論文に関連する単語
@@ -56,15 +49,6 @@ class Retrieve_Arxiv:
             properties, columns=["Title", "URL", "Date", "Abstruct", "Category"]
         )
         return df
-
-    def save_df_to_csv(self, df: pd.DataFrame) -> None:
-        """dfをCSVに保存する関数
-
-        Args:
-            df (pd.DataFrame): 取得した論文について必要な情報を抜き出したデータフレーム
-        """
-        filename = "/work/data/" + self.saved_file_name
-        df.to_csv(filename, encoding="utf-8")
 
     def __get_requests_message(self, keyword: str, max_num: int) -> str:
         """リクエストメッセージをコマンドライン引数から作成する内部関数


### PR DESCRIPTION
### 何ができるようになったか
Xmeansで分類できるようになった
keywordに空白を入れても動くようになった

### 実行手順(まとめて)
 docker compose up -dによってコンテナを立ち上げる。localhost:8000にアクセスする
 retrieve_and_classification.ipynbを全て実行する。キーワード、検索数、最大クラスタ数に分けて指定する
 re.retrieve()で検索、CSV作成
 cl.classification_papers_csv()でトピック分類(この時点ではディレクトリは作成されない)
 cl.make_and_save_topic_csv()でディレクトリ作成、CSVの保存
 data以下にキーワード名/トピック名のディレクトリが作成され、内部に論文をまとめたCSVが作成される

### その他やっておいたこと
入力させる数字は最大クラスタ数ということにしました
ラベルの確率などは不要かなと思って消してしまいました
retrive_paper_from_arxiv.pyのいくつかの機能が使われていなかったので消しました